### PR TITLE
Unreliable outcomes -> tweaking env config again

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ pebble:
       value: "0"
     ## ref: https://github.com/letsencrypt/pebble#authorization-reuse
     - name: PEBBLE_AUTHZREUSE
-      value: "0"
+      value: "100"
 ```
 
 See [Pebble's documentation](https://github.com/letsencrypt/pebble#testing-at-full-speed) for more info about its mischievous behavior.

--- a/pebble/values.yaml
+++ b/pebble/values.yaml
@@ -29,7 +29,7 @@ pebble:
       value: "0"
     ## ref: https://github.com/letsencrypt/pebble#authorization-reuse
     - name: PEBBLE_AUTHZREUSE
-      value: "0"
+      value: "100"
     # ## ref: https://github.com/letsencrypt/pebble#skipping-validation
     # - name: PEBBLE_VA_ALWAYS_VALID
     #   value: "0"


### PR DESCRIPTION
It seems that this gave us the most robust experience while testing the
JupyterHub helm chart with this helm chart. Due to this, I'm making it
the new default of this helm chart.