### PR TITLE
bump coredns from 1.9.1 to 1.9.3

### DIFF
--- a/pebble/values.yaml
+++ b/pebble/values.yaml
@@ -52,7 +52,7 @@ coredns:
   ## image ref: https://hub.docker.com/r/coredns/coredns/tags
   image:
     repository: coredns/coredns
-    tag: "1.9.1"
+    tag: "1.9.3"
 
   ## corefileSegment allow you to inject logic into CoreDNS's configuration
   ## file, called a Corefile. The example below will resolve all lookups of


### PR DESCRIPTION
Routine maintenance, want to rule out intermittent issues in z2jh related to acme setup fails related to antyhing in our control by bumping the version of coredns in case it possibly could cause trouble.