### PR TITLE
feat: replace merge with mergeOverwrite

### DIFF
--- a/pebble/templates/pebble-deployment.yaml
+++ b/pebble/templates/pebble-deployment.yaml
@@ -102,4 +102,4 @@ spec:
               scheme: HTTPS
 {{- end }}
 
-{{- include "pebble.deployment" . | fromYaml | merge .Values.pebble.merge.deployment | toYaml }}
+{{- include "pebble.deployment" . | fromYaml | mergeOverwrite .Values.pebble.merge.deployment | toYaml }}


### PR DESCRIPTION
Replace the merge command with mergeOverwrite so a the values in values.yaml will rule.

Another possible approach to make the 'replicas' field dynamic is to add a place holder {{ .Values.pebble.replicas }}
and a suitable field in values.yaml

The suggestion came from our need to scale down the Pebble pod due to issues in synchronism between Pebble cluster issuer and Certs-manager.