### PR TITLE
Bump pebble (2.6.0 to 2.8.0), coredns, and openssl

### DIFF
--- a/pebble/Chart.yaml
+++ b/pebble/Chart.yaml
@@ -4,7 +4,7 @@ version: 0.0.1-set.by.chartpress
 ## appVersion should be updated along with pebble releases
 ## ref: https://github.com/letsencrypt/pebble/releases
 ##
-appVersion: "2.6.0"
+appVersion: "2.8.0"
 description: |
   This Helm chart bootstraps Pebble: an ACME server (like Let's Encrypt) meant
   for testing. Pebble is also coupled to rely on pebble-challtestsrv as a DNS

--- a/pebble/values.yaml
+++ b/pebble/values.yaml
@@ -7,10 +7,11 @@ pebble:
     repository: ghcr.io/letsencrypt/pebble
     tag: "" # default is the chart's appVersion, this is an override
 
-  # Image for creating certificates
+  ## Image for creating certificates
+  ## ref: https://hub.docker.com/r/alpine/openssl/tags
   openssl:
     repository: docker.io/alpine/openssl
-    tag: "3.3.2"
+    tag: "3.5.1"
 
   ## config ref: https://github.com/letsencrypt/pebble/blob/52b92744eaad895ac25b19dae429c0bdd134b764/cmd/pebble/main.go#L17
   config:
@@ -57,7 +58,7 @@ coredns:
   ## image ref: https://hub.docker.com/r/coredns/coredns/tags
   image:
     repository: coredns/coredns
-    tag: "1.11.3"
+    tag: "1.12.2"
 
   ## corefileSegment allow you to inject logic into CoreDNS's configuration
   ## file, called a Corefile. The example below will resolve all lookups of


### PR DESCRIPTION
- pebble bumped from 2.6.0 to 2.8.0
- coredns bumped from 1.11.3 to 1.12.2
- aline/openssl bumped from 3.3.2 to 3.5.1
