### PR TITLE
Add imagePullSecrets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,28 +41,6 @@ To configure the Helm chart, create `my-values.yaml` to pass with the `--values`
 
 Helm charts _render templates_ into Kubernetes yaml files using _configurable values_. Helm charts contain default values, and these can be overridden in a merging process during chart installation and upgrades, for example with the `--values` flag to pass a [YAML](https://www.youtube.com/watch?v=cdLNKUoMc6c) file with values or with the `--set` flag to override specific keys' values.
 
-### Image pull secrets
-
-If you need to pull images from private registries, you can configure global `imagePullSecrets` that will be used for all containers (pebble, coredns, and test pods).
-
-```yaml
-# my-values.yaml
-imagePullSecrets:
-  - name: myregistrykey
-```
-
-First, create the secret in your namespace:
-
-```shell
-kubectl create secret docker-registry myregistrykey \
-  --docker-server=<your-registry-server> \
-  --docker-username=<your-username> \
-  --docker-password=<your-password> \
-  --docker-email=<your-email>
-```
-
-For more information, see the [Kubernetes documentation on pulling images from private registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
-
 ### CoreDNS configuration options
 
 Pebble as an ACME server during ACME challenges will make DNS lookups. This Helm chart makes those lookups go through a dedicated [CoreDNS](https://coredns.io/) DNS server that you can configure to manipulate what IP address various lookups should resolve to. Without additional configuration, it will just reference the Kubernetes cluster's DNS server.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,28 @@ To configure the Helm chart, create `my-values.yaml` to pass with the `--values`
 
 Helm charts _render templates_ into Kubernetes yaml files using _configurable values_. Helm charts contain default values, and these can be overridden in a merging process during chart installation and upgrades, for example with the `--values` flag to pass a [YAML](https://www.youtube.com/watch?v=cdLNKUoMc6c) file with values or with the `--set` flag to override specific keys' values.
 
+### Image pull secrets
+
+If you need to pull images from private registries, you can configure global `imagePullSecrets` that will be used for all containers (pebble, coredns, and test pods).
+
+```yaml
+# my-values.yaml
+imagePullSecrets:
+  - name: myregistrykey
+```
+
+First, create the secret in your namespace:
+
+```shell
+kubectl create secret docker-registry myregistrykey \
+  --docker-server=<your-registry-server> \
+  --docker-username=<your-username> \
+  --docker-password=<your-password> \
+  --docker-email=<your-email>
+```
+
+For more information, see the [Kubernetes documentation on pulling images from private registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+
 ### CoreDNS configuration options
 
 Pebble as an ACME server during ACME challenges will make DNS lookups. This Helm chart makes those lookups go through a dedicated [CoreDNS](https://coredns.io/) DNS server that you can configure to manipulate what IP address various lookups should resolve to. Without additional configuration, it will just reference the Kubernetes cluster's DNS server.

--- a/pebble/templates/coredns-deployment.yaml
+++ b/pebble/templates/coredns-deployment.yaml
@@ -18,6 +18,10 @@ spec:
         checksum/configmap: {{ include "pebble.coredns.configmap" . | fromYaml | merge .Values.coredns.merge.configmap | toYaml | sha256sum }}
     spec:
       terminationGracePeriodSeconds: 1
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 
       volumes:
         - name: coredns-configmap

--- a/pebble/templates/coredns-deployment.yaml
+++ b/pebble/templates/coredns-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         checksum/configmap: {{ include "pebble.coredns.configmap" . | fromYaml | merge .Values.coredns.merge.configmap | toYaml | sha256sum }}
     spec:
       terminationGracePeriodSeconds: 1
-      {{- with $.Values.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/pebble/templates/coredns-deployment.yaml
+++ b/pebble/templates/coredns-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 1
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
 
       volumes:

--- a/pebble/templates/pebble-deployment.yaml
+++ b/pebble/templates/pebble-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         checksum/configmap: {{ include "pebble.configmap" . | fromYaml | merge .Values.pebble.merge.configmap | toYaml | sha256sum }}
     spec:
       terminationGracePeriodSeconds: 1
-      {{- with $.Values.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/pebble/templates/pebble-deployment.yaml
+++ b/pebble/templates/pebble-deployment.yaml
@@ -18,6 +18,10 @@ spec:
         checksum/configmap: {{ include "pebble.configmap" . | fromYaml | merge .Values.pebble.merge.configmap | toYaml | sha256sum }}
     spec:
       terminationGracePeriodSeconds: 1
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 
       volumes:
         - name: pebble-config-and-tls-root

--- a/pebble/templates/pebble-deployment.yaml
+++ b/pebble/templates/pebble-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 1
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
 
       volumes:

--- a/pebble/templates/tests/coredns-pod.yaml
+++ b/pebble/templates/tests/coredns-pod.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations:
     "helm.sh/hook": test-success
 spec:
-  {{- with $.Values.imagePullSecrets }}
+  {{- with .Values.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/pebble/templates/tests/coredns-pod.yaml
+++ b/pebble/templates/tests/coredns-pod.yaml
@@ -15,6 +15,10 @@ metadata:
   annotations:
     "helm.sh/hook": test-success
 spec:
+  {{- with $.Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   initContainers:
     - name: dns-lookup
       image: quay.io/curl/curl:8.6.0

--- a/pebble/templates/tests/coredns-pod.yaml
+++ b/pebble/templates/tests/coredns-pod.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets:
-    {{- toYaml . | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
   initContainers:
     - name: dns-lookup

--- a/pebble/templates/tests/pebble-pod.yaml
+++ b/pebble/templates/tests/pebble-pod.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations:
     "helm.sh/hook": test-success
 spec:
-  {{- with $.Values.imagePullSecrets }}
+  {{- with .Values.imagePullSecrets }}
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/pebble/templates/tests/pebble-pod.yaml
+++ b/pebble/templates/tests/pebble-pod.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets:
-    {{- toYaml . | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
   initContainers:
     - name: acme

--- a/pebble/templates/tests/pebble-pod.yaml
+++ b/pebble/templates/tests/pebble-pod.yaml
@@ -14,6 +14,10 @@ metadata:
   annotations:
     "helm.sh/hook": test-success
 spec:
+  {{- with $.Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   initContainers:
     - name: acme
       image: quay.io/curl/curl:8.6.0

--- a/pebble/values.schema.json
+++ b/pebble/values.schema.json
@@ -29,6 +29,16 @@
   "type": "object",
 
   "properties": {
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" }
+        },
+        "required": ["name"]
+      }
+    },
     "pebble": {
       "type": "object",
       "properties": {

--- a/pebble/values.yaml
+++ b/pebble/values.yaml
@@ -1,6 +1,16 @@
 ## Values to render the Helm templates.
 fullnameOverride: ""
 
+## imagePullSecrets provides a global way to configure image pull secrets for
+## all containers. This is useful when pulling images from private registries.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+##
+## Example:
+## imagePullSecrets:
+##   - name: myregistrykey
+##
+imagePullSecrets: []
+
 pebble:
   image:
     ## repository ref: https://hub.docker.com/r/letsencrypt/pebble


### PR DESCRIPTION
# Add imagePullSecrets support

## Summary

This PR adds support for configuring `imagePullSecrets` globally for all containers in the Pebble Helm chart. This is useful when pulling images from private registries.

## Motivation

When deploying Pebble in environments that use private container registries, users need a way to configure image pull secrets. Currently, there's no built-in way to do this in the chart.

This change enables users to:
- Pull images from private registries
- Use custom/mirrored images
- Comply with security policies requiring authenticated image pulls

## Changes

### 1. Added `imagePullSecrets` to `values.yaml`
- New top-level configuration option
- Defaults to empty array `[]` (no change in default behavior)
- Includes documentation with example usage

### 2. Updated all pod templates
- `pebble-deployment.yaml`: Added imagePullSecrets to pod spec
- `coredns-deployment.yaml`: Added imagePullSecrets to pod spec
- `tests/pebble-pod.yaml`: Added imagePullSecrets to test pod
- `tests/coredns-pod.yaml`: Added imagePullSecrets to test pod

### 3. Updated `values.schema.json`
- Added schema validation for imagePullSecrets array
- Ensures proper structure with required `name` field

### 4. Updated `README.md`
- Added new section under "Chart configuration"
- Includes usage examples
- Links to Kubernetes documentation

## Testing

The changes have been validated:

```bash
# Lint check passes
helm lint pebble/
# Output: 1 chart(s) linted, 0 chart(s) failed

# Template renders correctly with imagePullSecrets
helm template test pebble/ --set 'imagePullSecrets[0].name=myregistrykey' | grep -A 2 "imagePullSecrets:"
# Output shows imagePullSecrets in all pod specs

# Template works without imagePullSecrets (backward compatible)
helm template test pebble/ | grep "imagePullSecrets:"
# Output: (empty - no imagePullSecrets rendered when not configured)
```

## Usage Example

```yaml
# my-values.yaml
imagePullSecrets:
  - name: myregistrykey
  - name: another-registry-secret
```

First create the secret:
```bash
kubectl create secret docker-registry myregistrykey \
  --docker-server=<your-registry-server> \
  --docker-username=<your-username> \
  --docker-password=<your-password> \
  --docker-email=<your-email>
```

Then install with the configuration:
```bash
helm install pebble pebble --values my-values.yaml
```

## Backward Compatibility

✅ Fully backward compatible
- Default value is empty array
- When not configured, no imagePullSecrets are rendered
- Existing deployments work without changes

## PR Checklist

- [x] Changes tested with `helm lint`
- [x] Changes tested with `helm template`
- [x] values.yaml updated with new configuration
- [x] values.schema.json updated
- [x] README.md updated with documentation
- [x] All pod templates updated (deployments + tests)
- [x] Backward compatible (default behavior unchanged)
- [x] Follows existing code style and patterns

